### PR TITLE
Fix roadmap diagram line over stage 7

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,10 +672,7 @@
           <!-- Línea 4-5 -->
           <div style="position: absolute; top: 50%; left: calc(57.12% - 12px); width: calc(14.28% + 24px); height: 4px; background: linear-gradient(90deg, var(--turquesa), var(--fucsia)); border-radius: 2px; transform: translateY(-50%); z-index: 1; box-shadow: 0 2px 8px rgba(255, 0, 80, 0.3);"></div>
           <!-- Línea 5-6 -->
-          <div style="position: absolute; top: 50%; left: calc(71.4% - 12px); width: calc(14.28% + 24px); height: 4px; background: linear-gradient(90deg, var(--fucsia), var(--turquesa)); border-radius: 2px; transform: translateY(-50%); z-index: 1; box-shadow: 0 2px 8px rgba(255, 0, 80, 0.3);"></div>
-          <!-- Línea 6-7 -->
-          <div style="position: absolute; top: 50%; left: calc(85.68% - 12px); width: calc(14.28% + 24px); height: 4px; background: linear-gradient(90deg, var(--turquesa), linear-gradient(135deg, var(--fucsia), var(--turquesa))); border-radius: 2px; transform: translateY(-50%); z-index: 1; box-shadow: 0 2px 8px rgba(255, 0, 80, 0.3);"></div>
-          
+          <div style="position: absolute; top: 50%; left: calc(71.4% - 12px); width: calc(14.28% + 12px); height: 4px; background: linear-gradient(90deg, var(--fucsia), var(--turquesa)); border-radius: 2px; transform: translateY(-50%); z-index: 1; box-shadow: 0 2px 8px rgba(255, 0, 80, 0.3);"></div>
           <!-- Contenedor de etapas -->
           <div style="display: grid; grid-template-columns: repeat(7, 1fr); gap: 24px; position: relative; z-index: 2;">
             


### PR DESCRIPTION
## Summary
- Remove connector line over stage 7 in slide roadmap
- Shorten preceding connector to avoid overlapping with stage 7 card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1ee685ec8328a981300d1d1e7f5c