### PR TITLE
Fix oversize research slide elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1232,26 +1232,26 @@
           <!-- Top Row: Key Statistics Images -->
           <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112609.png" alt="TikTok Users by Gender" style="width: 100%; height: 120px; object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112609.png" alt="TikTok Users by Gender" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112636.png" alt="TikTok Users by Age" style="width: 100%; height: 120px; object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112636.png" alt="TikTok Users by Age" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112415.png" alt="TikTok User Demographics" style="width: 100%; height: 120px; object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112415.png" alt="TikTok User Demographics" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112648.png" alt="TikTok Ad Revenue" style="width: 100%; height: 120px; object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112648.png" alt="TikTok Ad Revenue" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
             </div>
           </div>
-          
+
           <!-- Bottom Row: Main Analytics -->
           <div style="display: grid; grid-template-columns: 1fr 1fr 1.2fr; gap: 12px;">
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112345.png" alt="TikTok Creators by Age" style="width: 100%; height: 140px; object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112345.png" alt="TikTok Creators by Age" style="width: 100%; height: min(140px, 22vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112600.png" alt="TikTok Users by Country" style="width: 100%; height: 140px; object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112600.png" alt="TikTok Users by Country" style="width: 100%; height: min(140px, 22vh); object-fit: cover; border-radius: 6px;">
             </div>
             <!-- Key Insights Compact -->
             <div style="background: var(--blanco); border-radius: 12px; padding: 12px; box-shadow: var(--sombra); border-left: 4px solid var(--turquesa);">
@@ -1280,7 +1280,7 @@
           
           <!-- Colombia Specific Data -->
           <div style="background: var(--blanco); border-radius: 12px; padding: 10px; box-shadow: var(--sombra); overflow: hidden;">
-            <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112946.png" alt="TikTok Colombia Statistics" style="width: 100%; height: 100px; object-fit: cover; border-radius: 6px;">
+            <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112946.png" alt="TikTok Colombia Statistics" style="width: 100%; height: min(100px, 14vh); object-fit: cover; border-radius: 6px;">
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Make research & market analysis slide responsive by tying image heights to viewport height

## Testing
- `npx --yes html-validate index.html` *(fails: inline style and related warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b21214020832883f99ae19f25fc99