### PR TITLE
Reduce research slide collage size

### DIFF
--- a/index.html
+++ b/index.html
@@ -1228,30 +1228,30 @@
         </p>
 
         <!-- TikTok Statistics Collage -->
-        <div style="display: flex; flex-direction: column; gap: 16px; margin-top: 20px;">
+        <div style="display: flex; flex-direction: column; gap: 12px; margin-top: 20px;">
           <!-- Top Row: Key Statistics Images -->
-          <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+          <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;">
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112609.png" alt="TikTok Users by Gender" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112609.png" alt="TikTok Users by Gender" style="width: 100%; height: min(100px, 14vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112636.png" alt="TikTok Users by Age" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112636.png" alt="TikTok Users by Age" style="width: 100%; height: min(100px, 14vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112415.png" alt="TikTok User Demographics" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112415.png" alt="TikTok User Demographics" style="width: 100%; height: min(100px, 14vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112648.png" alt="TikTok Ad Revenue" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112648.png" alt="TikTok Ad Revenue" style="width: 100%; height: min(100px, 14vh); object-fit: cover; border-radius: 6px;">
             </div>
           </div>
 
           <!-- Bottom Row: Main Analytics -->
-          <div style="display: grid; grid-template-columns: 1fr 1fr 1.2fr; gap: 12px;">
+          <div style="display: grid; grid-template-columns: 1fr 1fr 1.2fr; gap: 8px;">
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112345.png" alt="TikTok Creators by Age" style="width: 100%; height: min(140px, 22vh); object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112345.png" alt="TikTok Creators by Age" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
             </div>
             <div style="background: var(--blanco); border-radius: 12px; padding: 8px; box-shadow: var(--sombra); overflow: hidden;">
-              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112600.png" alt="TikTok Users by Country" style="width: 100%; height: min(140px, 22vh); object-fit: cover; border-radius: 6px;">
+              <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112600.png" alt="TikTok Users by Country" style="width: 100%; height: min(120px, 18vh); object-fit: cover; border-radius: 6px;">
             </div>
             <!-- Key Insights Compact -->
             <div style="background: var(--blanco); border-radius: 12px; padding: 12px; box-shadow: var(--sombra); border-left: 4px solid var(--turquesa);">
@@ -1280,7 +1280,7 @@
           
           <!-- Colombia Specific Data -->
           <div style="background: var(--blanco); border-radius: 12px; padding: 10px; box-shadow: var(--sombra); overflow: hidden;">
-            <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112946.png" alt="TikTok Colombia Statistics" style="width: 100%; height: min(100px, 14vh); object-fit: cover; border-radius: 6px;">
+            <img src="images_tiktok_data/Captura de pantalla 2025-08-11 112946.png" alt="TikTok Colombia Statistics" style="width: 100%; height: min(80px, 12vh); object-fit: cover; border-radius: 6px;">
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Shrink image collage in Research & Market Analysis slide by reducing image heights and spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b288c37a08328af32d62c1a0a1efc